### PR TITLE
docs: fix TPS latency formulas

### DIFF
--- a/docs/blog/posts/2026_03_improve_latency_estimation.md
+++ b/docs/blog/posts/2026_03_improve_latency_estimation.md
@@ -17,7 +17,7 @@ We have made an improvement regarding how we estimate the **generation latency**
 The new generation latency calculation is now:
 
 $$
-\text{generation latency} = \text{time to first token} + \text{throughput} \times \text{output tokens}
+\text{generation latency} = \text{time to first token} + \frac{\text{output tokens}}{\text{throughput}}
 $$
 
 With:

--- a/docs/methodology/llm_inference.md
+++ b/docs/methodology/llm_inference.md
@@ -114,7 +114,7 @@ It is decomposed into two phases: the **pre-fill latency** (or time-to-first-tok
 Using these values, we can estimate the generation latency for the entire request given the number of output tokens, $\#T_{\text{out}}$. When possible, we also measure the request latency, $\Delta T_{\text{request}}$, and use it as the maximum bound for the generation latency:
 
 $$
-\Delta T(\#T_{\text{out}}) = \min \left\{ \text{TTFT} + \#T_{\text{out}} \times \text{TPS}, \Delta T_{\text{request}}\right\}.
+\Delta T(\#T_{\text{out}}) = \min \left\{ \text{TTFT} + \frac{\#T_{\text{out}}}{\text{TPS}}, \Delta T_{\text{request}}\right\}.
 $$
 
 


### PR DESCRIPTION
Correct the generation latency equations in the LLM methodology page and March 2026 blog post. Since TPS is measured in tokens per second, decode latency is output tokens divided by TPS rather than multiplied by it. The implementation already uses the correct reciprocal calculation and remains unchanged.

Validation: `uv run --group docs mkdocs build --strict`