### PR TITLE
fix: relax packaging dependency constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "wrapt>=1.14.1,<2.0.0",
     "pydantic>=1.9.0,<3",
-    "packaging>=24.2,<25.0",
+    "packaging>=24.2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
     "pre-commit>=4.2.0",
     "pytest>=7.2.0",
     "pytest-recording>=0.13.1",
+    "vcrpy>=8.2.1",
     "pytest-dotenv>=0.5.2",
     "pytest-asyncio>=0.23.6",
     "numpy>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -706,6 +706,7 @@ dev = [
     { name = "pytest-recording" },
     { name = "setuptools" },
     { name = "toml" },
+    { name = "vcrpy" },
 ]
 docs = [
     { name = "mike" },
@@ -751,6 +752,7 @@ dev = [
     { name = "pytest-recording", specifier = ">=0.13.1" },
     { name = "setuptools", specifier = ">=80.9.0" },
     { name = "toml", specifier = ">=0.10.2" },
+    { name = "vcrpy", specifier = ">=8.2.1" },
 ]
 docs = [
     { name = "mike", specifier = ">=2.1.2" },
@@ -3704,15 +3706,15 @@ wheels = [
 
 [[package]]
 name = "vcrpy"
-version = "8.1.1"
+version = "8.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/07/bcfd5ebd7cb308026ab78a353e091bd699593358be49197d39d004e5ad83/vcrpy-8.1.1.tar.gz", hash = "sha256:58e3053e33b423f3594031cb758c3f4d1df931307f1e67928e30cf352df7709f", size = 85770, upload-time = "2026-01-04T19:22:03.886Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/d5/8a1f8eb603e2d35fbb0ecd1e309d0c5c18a0ecfc8c0a8f04088bbc8f833b/vcrpy-8.3.0.tar.gz", hash = "sha256:46d64e77e8d95e5c76c7d9a94ff05d8b38b2ae4e1d4869eb0235024b6fcb5212", size = 96117, upload-time = "2026-07-04T14:27:01.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/d7/f79b05a5d728f8786876a7d75dfb0c5cae27e428081b2d60152fb52f155f/vcrpy-8.1.1-py3-none-any.whl", hash = "sha256:2d16f31ad56493efb6165182dd99767207031b0da3f68b18f975545ede8ac4b9", size = 42445, upload-time = "2026-01-04T19:22:02.532Z" },
+    { url = "https://files.pythonhosted.org/packages/34/77/cb4219be91508399cbcb6143bad89462cfb16f6c638458f454a5d46ac95a/vcrpy-8.3.0-py3-none-any.whl", hash = "sha256:bd66e6143746778157f00e2a922527a8d96b2fdc350be8988a45a29c843815b9", size = 46530, upload-time = "2026-07-04T14:27:00.546Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -731,7 +731,7 @@ requires-dist = [
     { name = "opentelemetry-api", marker = "extra == 'opentelemetry'", specifier = ">=1.32.1,<2.0.0" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'opentelemetry'", specifier = ">=1.32.1,<2.0.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'opentelemetry'", specifier = ">=1.32.1,<2.0.0" },
-    { name = "packaging", specifier = ">=24.2,<25.0" },
+    { name = "packaging", specifier = ">=24.2" },
     { name = "pydantic", specifier = ">=1.9.0,<3" },
     { name = "rapidfuzz", marker = "extra == 'litellm'", specifier = ">=3.12.1,<4.0.0" },
     { name = "tiktoken", marker = "extra == 'huggingface-hub'", specifier = ">=0.8.0,<0.13.0" },
@@ -776,7 +776,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
## Summary
Relax the Ecologits packaging dependency to remove the `<25.0` cap and allow newer environments such as Airflow 3.1.x to install cleanly.

## Validation
Ran `uv run --group dev --all-extras --with packaging==25.0 pytest tests/test_version.py tests/test_huggingface_hub.py -q` successfully.

## Notes
The lockfile refresh also updates the resolved `exceptiongroup` metadata recorded by `uv.lock`.
