### PR TITLE
docs: update calculator links

### DIFF
--- a/docs/blog/posts/2025_11_methodology_update.md
+++ b/docs/blog/posts/2025_11_methodology_update.md
@@ -83,7 +83,7 @@ We also reduced the hardware lifetime from 5 to 3 years, reflecting [recent repo
 
 **Better latency estimations in EcoLogits Calculator**
 
-We improved latency calculations in the [EcoLogits Calculator](https://huggingface.co/spaces/genai-impact/ecologits-calculator) by incorporating model and provider throughput data from [OpenRouter](https://openrouter.ai/). This provides a more accurate estimate of execution duration and, consequently, environmental impacts. Note that this change does not affect the EcoLogits Python library, which relies on direct latency measurements.
+We improved latency calculations in the [EcoLogits Calculator](https://calculator.ecologits.ai/) by incorporating model and provider throughput data from [OpenRouter](https://openrouter.ai/). This provides a more accurate estimate of execution duration and, consequently, environmental impacts. Note that this change does not affect the EcoLogits Python library, which relies on direct latency measurements.
 
 ## Comparison with other disclosures from the AI providers
 

--- a/docs/blog/posts/2026_03_improve_latency_estimation.md
+++ b/docs/blog/posts/2026_03_improve_latency_estimation.md
@@ -27,6 +27,6 @@ With:
 
 These two metrics are being collected from [OpenRouter](https://openrouter.ai/), a service that centralizes the access to many AI providers with a single API key. Since the service is widely adopted (**over 30 trillion tokens per month**) the average data should be representative of real-world conditions.
 
-This work extends what was [previously done](2025_11_methodology_update.md#other-minor-changes) to patch the energy and impacts overestimations we had in [EcoLogits Calculator](https://huggingface.co/spaces/genai-impact/ecologits-calculator) compared to the Python library. Having this new estimation method in our core methodology makes it more reliable and reusable in all projects that depend on EcoLogits.
+This work extends what was [previously done](2025_11_methodology_update.md#other-minor-changes) to patch the energy and impacts overestimations we had in [EcoLogits Calculator](https://calculator.ecologits.ai/) compared to the Python library. Having this new estimation method in our core methodology makes it more reliable and reusable in all projects that depend on EcoLogits.
 
 It is important to note that the **old method** to estimate generation latency using the [ML.ENERGY Leaderboard](https://ml.energy/leaderboard/?__theme=light) is **still being used when TTFT and TPS values are not available** on OpenRouter. This is the case for the Hugging Face inference provider that we support.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,7 +19,7 @@ On the other hand EcoLogits is designed for scenarios where you do not have acce
 
 ## How can I estimate impacts of general use of GenAI models? 
 
-If you want to estimate the environmental impacts of using generative AI models without coding or making request, we recommend you to use our online webapp [EcoLogits Calculator :octicons-link-external-16:](https://huggingface.co/spaces/genai-impact/ecologits-calculator).
+If you want to estimate the environmental impacts of using generative AI models without coding or making request, we recommend you to use our online webapp [EcoLogits Calculator :octicons-link-external-16:](https://calculator.ecologits.ai/).
 
 
 ## How do we assess impacts for proprietary models?

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,11 +34,11 @@ hide:
             <h3>EcoLogits Calculator</h3>
         </div>
         <div class="card-content">
-            <a href="https://huggingface.co/spaces/genai-impact/ecologits-calculator" target="_blank">
+            <a href="https://calculator.ecologits.ai/" target="_blank">
                 <img src="assets/calculator_screenshot.png" alt="Calculator Icon">
             </a>
             <p>A <b>user-friendly web tool</b> for estimating the environmental footprint of AI models with just a few clicks.</p>
-            <p><a href="https://huggingface.co/spaces/genai-impact/ecologits-calculator" target="_blank">Visit EcoLogits Calculator <span class="twemoji"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2m6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.75.75 0 0 1-1.042-.018.75.75 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1"></path></svg></span></a></p>
+            <p><a href="https://calculator.ecologits.ai/" target="_blank">Visit EcoLogits Calculator <span class="twemoji"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2m6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.75.75 0 0 1-1.042-.018.75.75 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1"></path></svg></span></a></p>
         </div>
     </div>
     <div class="project-card">
@@ -93,7 +93,7 @@ People who contribute significantly to the project.
     </div>
   </div>
   <div class="contributor-card">
-    <img src="https://raw.githubusercontent.com/genai-impact/website/refs/heads/main/assets/images/people/claire_saignol.jpg" alt="Claire Saignol">
+    <img src="https://avatars.githubusercontent.com/u/280668843?v=4" alt="Claire Saignol">
     <div class="contributor-info">
       <span class="contributor-name">Claire Saignol</span>
       <span class="contributor-role">Sustainability Manager</span>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,7 @@ nav:
   - 'API Reference': reference/
   - 'Blog':
       - blog/index.md
-  - 'EcoLogits Calculator': 'https://huggingface.co/spaces/genai-impact/ecologits-calculator'
+  - 'EcoLogits Calculator': 'https://calculator.ecologits.ai/'
   - 'EcoLogits API': 'https://api.ecologits.ai/docs'
 
 theme:


### PR DESCRIPTION
Updates the docs navigation, home page, FAQ, and related blog posts to point EcoLogits Calculator links to https://calculator.ecologits.ai/. Replaces Claire Saignol's contributor image URL with her GitHub avatar.