### PR TITLE
docs: link video generation paper

### DIFF
--- a/docs/blog/posts/2026_06_video_impacts.md
+++ b/docs/blog/posts/2026_06_video_impacts.md
@@ -36,7 +36,7 @@ One key learning from this work is simple: **the more you ask, the greater the e
 
 The environmental impacts are estimated using a bottom-up methodology, similar to the one we have already published and continue to maintain for text generation. A core part of the method is estimating the direct electricity consumption of the servers and infrastructure that support AI video models.
 
-This is where SAIG's work is being integrated into EcoLogits. They developed benchmarks of open models to understand how generation latency for a single video can be estimated from the requested duration and resolution, as well as the model and infrastructure provider. Their academic paper is still under preparation and will be available soon.
+This is where SAIG's work is being integrated into EcoLogits. They developed benchmarks of open models to understand how generation latency for a single video can be estimated from the requested duration and resolution, as well as the model and infrastructure provider. Their academic paper is now available on arXiv: [Jegham et al. (2026)](https://arxiv.org/abs/2607.04553).
 
 From the estimated electricity consumption and hardware use, we then deduce environmental impacts using a life cycle assessment approach. EcoLogits models provider data-center overhead and locations to estimate greenhouse gas emissions and water consumption during the use phase. It also accounts for hardware manufacturing impacts, reusing work from Boavizta, Hubblo, and academic research on AI hardware life-cycle impacts ([Schneider et al., 2025](https://arxiv.org/abs/2502.01671)).
 

--- a/docs/methodology/video_generation.md
+++ b/docs/methodology/video_generation.md
@@ -22,9 +22,7 @@ To assess the usage impacts of a video generation request, we first estimate the
 
 ### Modeling the generation latency
 
-[//]: # (TODO: Add paper link)
-
-Our latency estimation follows the approach from [Jegham et al. (2026)](#). The main idea is that video generation is mostly compute-bound, so under fixed hardware the generation time is a good proxy for the computational work of the request. In practice, we use model-specific regressions fitted from observed generation latencies, directly derived from the paper.
+Our latency estimation follows the approach from [Jegham et al. (2026)](https://arxiv.org/abs/2607.04553). The main idea is that video generation is mostly compute-bound, so under fixed hardware the generation time is a good proxy for the computational work of the request. In practice, we use model-specific regressions fitted from observed generation latencies, directly derived from the paper.
 
 We denote:
 
@@ -81,9 +79,7 @@ $$
 
 Each video model is mapped to a fixed hardware configuration. The supported configurations currently include NVIDIA DGX GPU servers and TPU servers.
 
-[//]: # (TODO: Add paper link)
-
-We denote by $P_{\text{server}}$ the electrical power of the full machine, including the base server and all installed accelerators. The power consumptions for each server is derived from [Jegham et al. (2026)](#). The server energy consumed during the request is:
+We denote by $P_{\text{server}}$ the electrical power of the full machine, including the base server and all installed accelerators. The power consumptions for each server is derived from [Jegham et al. (2026)](https://arxiv.org/abs/2607.04553). The server energy consumed during the request is:
 
 $$
 E_{\text{server}} = \frac{\Delta T}{3600} \times P_{\text{server}},
@@ -206,9 +202,7 @@ We use provider-level assumptions for the default **deployment location**, **PUE
 
 ## References
 
-[//]: # (TODO: add paper link)
-
-- [Jegham et al. (2026)](#) for video generation latency and power consumption.
+- [Jegham et al. (2026)](https://arxiv.org/abs/2607.04553) for video generation latency and power consumption.
 - [Schneider et al. (2025)](https://arxiv.org/abs/2502.01671) for TPU embodied GWP values.
 - [Boavizta](https://boavizta.org/) and [BoaviztAPI](https://github.com/Boavizta/boaviztapi) for embodied impacts of the modeled hardware configurations.
 - [Our World in Data](https://ourworldindata.org/), [ADEME Base Empreinte®](https://base-empreinte.ademe.fr/), and [World Resource Institute](https://www.wri.org/) for electricity-mix and water-use factors.


### PR DESCRIPTION
## Summary
- Link Jegham et al. (2026) citations in the video generation methodology to the arXiv paper.
- Replace the blog post's coming-soon wording with the published arXiv link.

## Testing
- Not run; documentation-only change.