### PR TITLE
ci: run the test suite on every supported Python version

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,13 +8,18 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+    name: pytest (python ${{ matrix.python-version }})
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
       - name: Install dependencies
         run: uv sync --locked --all-extras --group dev


### PR DESCRIPTION
## Describe your changes

`pyproject.toml` promises five Python versions, in the classifiers and in `requires-python = ">=3.10,<4"`:

```
Programming Language :: Python :: 3.10
Programming Language :: Python :: 3.11
Programming Language :: Python :: 3.12
Programming Language :: Python :: 3.13
Programming Language :: Python :: 3.14
```

`pytest.yaml` pins `python-version: '3.13'`, and there is no tox or nox picking up the rest. So four of the five promised versions are never exercised, and a 3.10-only break would ship unnoticed.

This adds a matrix over exactly the versions the classifiers list, with `fail-fast: false` so one red version does not hide the state of the others.

**I ran the suite on all five before proposing this**, so this is not a guess about whether they still work:

| Python | Result |
|---|---|
| 3.10 | 188 passed, 5 skipped |
| 3.11 | 188 passed, 5 skipped |
| 3.12 | 188 passed, 5 skipped |
| 3.13 | 188 passed, 5 skipped |
| 3.14 | 188 passed, 5 skipped |

The support is real. It just was not guarded, which is the part this fixes.

On CI minutes: this turns one job into five, and the suite takes well under a minute, so it should be cheap. If that is still too much on every PR, the other shape is a full matrix on push to `main` and a single version on pull requests. Either works for me, your call.

No issue opened for this, since it is a one file change. Can open one if you track things that way.

## Checklist:

- [x] I have read and followed the [contribution guide](https://ecologits.ai/latest/contributing/).
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works. — this change *is* test configuration, there is nothing to add a test for
- [x] I have successfully run all tests with `make test`. — run on all five versions, table above
- [ ] I have successfully run pre-commit with `make pre-commit`. — not run, this touches only a workflow file
- [ ] I have written documentation for the changes. — no user facing change
- [x] I have rebased my branch onto the target branch (usually `main`).